### PR TITLE
Updating to work with latest cryptoparser version

### DIFF
--- a/dheater/__main__.py
+++ b/dheater/__main__.py
@@ -15,7 +15,8 @@ import abc
 import attr
 import urllib3
 
-from cryptoparser.common.algorithm import Authentication
+from cryptodatahub.common.algorithm import Authentication
+
 from cryptoparser.common.exception import InvalidType, NotEnoughData
 
 from cryptoparser.tls.algorithm import TlsSignatureAndHashAlgorithm
@@ -23,7 +24,7 @@ from cryptoparser.tls.ciphersuite import TlsCipherSuite
 from cryptoparser.tls.extension import TlsNamedCurve, TlsExtensionEllipticCurves
 from cryptoparser.tls.record import TlsRecord
 from cryptoparser.tls.subprotocol import TlsHandshakeType
-from cryptoparser.tls.version import TlsProtocolVersionFinal, TlsVersion
+from cryptoparser.tls.version import TlsProtocolVersion, TlsVersion
 
 from cryptoparser.ssh.record import SshRecordInit, SshRecordKexDH, SshRecordKexDHGroup
 from cryptoparser.ssh.subprotocol import (
@@ -345,7 +346,7 @@ class DHEnforcerThreadSSH(DHEnforcerThreadBase):
 @attr.s
 class DHEPreCheckResultTLS(DHEPreCheckResultBase):  # pylint: disable=too-few-public-methods
     dh_public_key = attr.ib(validator=attr.validators.instance_of((DHPublicKey, TlsNamedCurve)))
-    protocol_version = attr.ib(validator=attr.validators.instance_of(TlsProtocolVersionFinal))
+    protocol_version = attr.ib(validator=attr.validators.instance_of(TlsProtocolVersion))
     cipher_suite = attr.ib(validator=attr.validators.instance_of(TlsCipherSuite))
     receivable_byte_count = attr.ib(validator=attr.validators.instance_of(int))
 
@@ -373,7 +374,7 @@ class DHEnforcerThreadTLS(DHEnforcerThreadBase):
 
         protocol_version = max(analyzer_result_versions.versions)
         dh_public_key = None
-        if protocol_version > TlsProtocolVersionFinal(TlsVersion.TLS1_2):
+        if protocol_version > TlsProtocolVersion(TlsVersion.TLS1_2):
             named_curves = list(sorted(
                 TlsHandshakeClientHelloKeyExchangeDHE._NAMED_CURVES,  # pylint: disable=protected-access
                 key=lambda named_curve: named_curve.value.named_group.value.size, reverse=True
@@ -455,7 +456,7 @@ class DHEnforcerThreadTLS(DHEnforcerThreadBase):
             ]
 
         client_hello_class = TlsHandshakeClientHelloSpecalization
-        if protocol_version > TlsProtocolVersionFinal(TlsVersion.TLS1_2):
+        if protocol_version > TlsProtocolVersion(TlsVersion.TLS1_2):
             signature_algorithms = None
             extensions = client_hello_class._get_tls1_3_extensions(  # pylint: disable=protected-access
                     [protocol_version, ], [self.pre_check_result.dh_public_key, ], signature_algorithms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 attrs>=19.2.0
-cryptodatahub>=0.8.5,<0.9.0
-cryptoparser>=0.8.0,<0.9.0
-cryptolyzer>=0.8.0,<0.9.0
+cryptolyzer>=0.8.5
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 attrs>=19.2.0
+cryptodatahub>=0.8.5,<0.9.0
 cryptoparser>=0.8.0,<0.9.0
 cryptolyzer>=0.8.0,<0.9.0
 urllib3


### PR DESCRIPTION
Hi there, when I install the latest version of dheater (0.3.2) and try to run it, I get this error:
```
root@brahms:~# dheat -h
Traceback (most recent call last):
  File "/usr/local/bin/dheat", line 5, in <module>
    from dheater.__main__ import main
  File "/usr/local/lib/python3.8/dist-packages/dheater/__main__.py", line 18, in <module>
    from cryptoparser.common.algorithm import Authentication
ModuleNotFoundError: No module named 'cryptoparser.common.algorithm'
```
I noticed that some of the code in `cryptoparser` was moved to `cryptodatahub`, so I think made the changes in dheater to address those changes.